### PR TITLE
Linux compatibility

### DIFF
--- a/ipysketch/app.py
+++ b/ipysketch/app.py
@@ -39,7 +39,7 @@ class Application(tk.Tk):
             self.iconbitmap(icon)
         png = pkg_resources.resource_filename('ipysketch', os.path.join('assets', 'logo.png'))
         png = Image.open(png)
-        self.iconphoto(True, ImageTk.PhotoImage(png))
+        self.iconphoto(False, ImageTk.PhotoImage(png))
         self.title('ipysketch ' + name)
 
     def _configure_window(self):

--- a/ipysketch/app.py
+++ b/ipysketch/app.py
@@ -3,6 +3,7 @@ import pkg_resources
 
 import pickle
 import os
+import sys
 import io
 from PIL import Image, ImageTk
 
@@ -34,7 +35,8 @@ class Application(tk.Tk):
         self.wait_visibility()
         self.attributes('-topmost', False)
         icon = pkg_resources.resource_filename('ipysketch', os.path.join('assets', 'logo.ico'))
-        self.iconbitmap(icon)
+        if sys.platform.startswith('win'):
+            self.iconbitmap(icon)
         png = pkg_resources.resource_filename('ipysketch', os.path.join('assets', 'logo.png'))
         png = Image.open(png)
         self.iconphoto(True, ImageTk.PhotoImage(png))

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     packages=find_packages(exclude=("tests",)),
     package_dir={name: name},
     include_package_data=True,
+    package_data={name:['assets/*']},
     license='GPLv3',
     description=description,
     long_description=open('res/README_pypi.md').read() if exists('README.md') else '',


### PR DESCRIPTION
This pull request allows ipysketch to run on *nix based machines. However, it does lose the menu bar icon. I believe it leaves, ipysketch functioning normally on Windows. I do not know enough about TK applications to get the icon working on *nix. Tested on Ubuntu 20.04 and within Jupyter running on locally on it.